### PR TITLE
[#1131] Fix saved answers are reset by prefilled

### DIFF
--- a/app/src/form/components/Question.js
+++ b/app/src/form/components/Question.js
@@ -78,7 +78,17 @@ const Question = memo(({ group, activeQuestions = [], index }) => {
         });
         FormState.update((s) => {
           const preValues = preFilled?.fill?.reduce((prev, current) => {
-            return { [current['id']]: current['answer'], ...prev };
+            /**
+             * Make sure the answer criteria are not replaced by previous values
+             * eg:
+             * Previous value = "Update"
+             * Answer criteria = "New"
+             */
+            const answer =
+              id === current['id']
+                ? current['answer']
+                : values?.[current['id']] || current['answer'];
+            return { [current['id']]: answer, ...prev };
           }, {});
           s.prefilled = preValues;
         });


### PR DESCRIPTION
## TODO/DONE

- [x] Fix saved answers are reset by prefilled

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204615985394952