### PR TITLE
[#1384] Add administration_id to device/datapoint-list responses

### DIFF
--- a/backend/api/v1/v1_mobile/serializers.py
+++ b/backend/api/v1/v1_mobile/serializers.py
@@ -16,6 +16,7 @@ class MobileDataPointDownloadListSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     form_id = serializers.IntegerField()
     name = serializers.CharField()
+    administration_id = serializers.IntegerField()
     url = serializers.SerializerMethodField()
     last_updated = serializers.SerializerMethodField()
 
@@ -28,7 +29,14 @@ class MobileDataPointDownloadListSerializer(serializers.Serializer):
         return obj["updated"] if obj["updated"] else obj["created"]
 
     class Meta:
-        fields = ["id", "form_id", "name", "url", "last_updated"]
+        fields = [
+            "id",
+            "form_id",
+            "name",
+            "administration_id",
+            "url",
+            "last_updated",
+        ]
 
 
 class MobileFormSerializer(serializers.ModelSerializer):

--- a/backend/api/v1/v1_mobile/tests/tests_mobile_datapoint_sync.py
+++ b/backend/api/v1/v1_mobile/tests/tests_mobile_datapoint_sync.py
@@ -13,18 +13,16 @@ from rest_framework import status
 
 class MobileDataPointDownloadListTestCase(TestCase):
     def setUp(self):
-        call_command('administration_seeder', '--test')
-        call_command('form_seeder', '--test')
+        call_command("administration_seeder", "--test")
+        call_command("form_seeder", "--test")
 
         self.user = SystemUser.objects.create_user(
-            email='test@test.org',
-            password='test1234',
-            first_name='test',
-            last_name='testing',
+            email="test@test.org",
+            password="test1234",
+            first_name="test",
+            last_name="testing",
         )
-        self.administrations = Administration.objects.filter(
-            level__level=2
-        )
+        self.administrations = Administration.objects.filter(level__level=2)
         self.administration = self.administrations.first()
         role = UserRoleTypes.user
         self.user_access = Access.objects.create(
@@ -32,12 +30,12 @@ class MobileDataPointDownloadListTestCase(TestCase):
         )
         self.forms = Forms.objects.filter(
             type=FormTypes.county,
-            submission_types__contains=[SubmissionTypes.certification]
+            submission_types__contains=[SubmissionTypes.certification],
         ).all()
-        self.uuid = '1234'
-        self.passcode = 'passcode1234'
+        self.uuid = "1234"
+        self.passcode = "passcode1234"
         self.mobile_assignment = MobileAssignment.objects.create_assignment(
-            user=self.user, name='test', passcode=self.passcode
+            user=self.user, name="test", passcode=self.passcode
         )
         self.administration_children = Administration.objects.filter(
             parent=self.administration
@@ -65,7 +63,7 @@ class MobileDataPointDownloadListTestCase(TestCase):
         self.mobile_assignment.certifications.add(
             *self.cert_administration_children
         )
-        self.cert_uuid = '5678'
+        self.cert_uuid = "5678"
         self.form_data_cert = FormData.objects.create(
             name="TEST",
             geo=None,
@@ -77,20 +75,20 @@ class MobileDataPointDownloadListTestCase(TestCase):
         )
 
     def test_get_datapoints_list_url(self):
-        code = {'code': self.passcode}
+        code = {"code": self.passcode}
         response = self.client.post(
-            '/api/v1/device/auth',
+            "/api/v1/device/auth",
             code,
-            content_type='application/json',
+            content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        token = response.data['syncToken']
+        token = response.data["syncToken"]
         url = "/api/v1/device/datapoint-list/"
         response = self.client.get(
             url,
             follow=True,
-            content_type='application/json',
-            **{'HTTP_AUTHORIZATION': f'Bearer {token}'},
+            content_type="application/json",
+            **{"HTTP_AUTHORIZATION": f"Bearer {token}"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
@@ -98,37 +96,44 @@ class MobileDataPointDownloadListTestCase(TestCase):
         self.assertEqual(data["data"][0]["id"], self.form_data.id)
         self.assertEqual(data["data"][0]["name"], self.form_data.name)
         self.assertEqual(data["data"][0]["form_id"], self.forms[0].id)
+        self.assertEqual(
+            data["data"][0]["administration_id"],
+            self.form_data.administration.id,
+        )
         self.assertFalse(self.mobile_assignment.last_synced_at, None)
         # test if url is correct
         self.assertEqual(
-            data["data"][0]["url"],
-            f"{WEBDOMAIN}/datapoints/{self.uuid}.json"
+            data["data"][0]["url"], f"{WEBDOMAIN}/datapoints/{self.uuid}.json"
         )
         self.assertEqual(
             list(data["data"][0]),
-            ["id", "form_id", "name", "url", "last_updated"]
+            [
+                "id",
+                "form_id",
+                "name",
+                "administration_id",
+                "url",
+                "last_updated",
+            ],
         )
 
         # test for certification datapoints
 
         form_data = FormData.objects.all()
         self.assertEqual(len(form_data), 2)
-        self.assertNotEqual(form_data[0].administration,
-                            form_data[1].administration)
+        self.assertNotEqual(
+            form_data[0].administration, form_data[1].administration
+        )
         self.assertTrue(self.mobile_assignment.certifications.all())
 
         url = "/api/v1/device/datapoint-list/?certification=true"
         response = self.client.get(
             url,
             follow=True,
-            content_type='application/json',
-            **{'HTTP_AUTHORIZATION':
-                f'Bearer {token}'},
+            content_type="application/json",
+            **{"HTTP_AUTHORIZATION": f"Bearer {token}"},
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertEqual(data["total"], 1)
-        self.assertEqual(
-            data["data"][0]["id"],
-            self.form_data_cert.id
-        )
+        self.assertEqual(data["data"][0]["id"], self.form_data_cert.id)

--- a/backend/api/v1/v1_mobile/views.py
+++ b/backend/api/v1/v1_mobile/views.py
@@ -485,7 +485,13 @@ def get_datapoint_download_list(request, version):
         )
 
     queryset = queryset.values(
-        "uuid", "id", "form_id", "name", "created", "updated"
+        "uuid",
+        "id",
+        "form_id",
+        "name",
+        "administration_id",
+        "created",
+        "updated",
     ).order_by("-created")
 
     instance = paginator.paginate_queryset(queryset, request)


### PR DESCRIPTION
### TODO / DONE

---

- #1384 
- [ ] Backend: Add administration_id into device/datapoint-list responses
- [ ] Mobile: Add administration_id column into certifications table
- [ ] Mobile: Create administration dropdown filter on certifications datapoint list page
- [ ] Mobile: Handle on filter by selected administration


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206931263234445